### PR TITLE
Remove env from tracking and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+.env
 .vscode


### PR DESCRIPTION
last pull i removed .env but the ".env" addition to gitignore didn't go so anyone who pulls and does another PR would be adding the .env back to github. This resolves that