### PR TITLE
create terms and conditions and update signup page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "prettier": "3.1.1",
     "react-router-dom": "^6.21.1"
   }

--- a/client/src/components/Terms.js
+++ b/client/src/components/Terms.js
@@ -1,0 +1,58 @@
+
+'use client';
+import { Link } from 'react-router-dom';
+import { Modal } from 'flowbite-react';
+import { useState } from 'react';
+
+export default function Terms() {
+  const [openModal, setOpenModal] = useState(false);
+
+  return (
+    <>
+      <Link onClick={() => setOpenModal(true)}>Terms and Conditions</Link>
+      <Modal show={openModal} onClose={() => setOpenModal(false)}>
+        <Modal.Header>Terms and Conditions for Nourish Community Board</Modal.Header>
+        <Modal.Body>
+          <div className="space-y-6">
+            <p className="text-base italic leading-relaxed text-gray-700 dark:text-gray-500">
+                Last Updated: December, 28th 2023
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                Welcome to the Community Board of Nourish, an app dedicated to helping users find community fridges in Philadelphia ("Service"). This Community Board is provided by Nourish ("Company", "we", "our", "us"). These Terms and Conditions ("Terms") govern your access to and use of the Community Board.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                By accessing or using the Community Board, you agree to be bound by these Agreements, which include these Terms and our Privacy Policy. If you do not agree with any part of these terms, you are not permitted to access the Community Board.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                The Community Board is a platform for users to exchange information, insights, and discussions relevant to community fridges in Philadelphia. Use of the Community Board should be responsible and in line with the purpose of the Service.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                As a user of the Community Board, you agree not to post or share content that is:
+            </p>
+            <ul className="list-disc text-base text-gray-500 dark:text-gray-400 ml-8">
+                <li>Illegal, harmful, or offensive, including threatening, abusive, defamatory, or discriminatory material.</li>
+                <li>Infringing upon the rights of others, including intellectual property.</li>
+                <li>Linked to harmful software or materials.</li>
+                <li>False or misleading, including impersonation of others.</li>
+            </ul>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                We reserve the right to moderate, edit, or remove content that we determine to be in violation of these Terms or that we find objectionable for any reason.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                If you create an account on the Community Board, you are responsible for safeguarding your account and for all activities occurring under your account.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                The Community Board and Nourish app are provided "as is" without any warranties, expressed or implied. We do not guarantee uninterrupted or error-free service.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                We may update these Terms from time to time. Notice of significant changes will be posted on the Community Board or our website.
+            </p>
+            <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                These Terms are governed by the laws of Pennsylvania, United States, without regard to its conflict of law principles.
+            </p>
+          </div>
+        </Modal.Body>
+      </Modal>
+    </>
+  );
+}

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import Navbar from '../components/Navbar';
+import Terms from '../components/Terms';
 
 export default function Login() {
   return (
@@ -40,7 +41,8 @@ export default function Login() {
                     <input id="terms" aria-describedby="terms" type="checkbox" className="w-4 h-4 border border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-green-300" required />
                   </div>
                   <div className="ml-3 text-sm">
-                    <label htmlFor="terms" className="font-light text-gray-500">I accept the <Link className="font-medium text-green-500 hover:underline" to="#">Terms and Conditions</Link></label>
+                    
+                    <label htmlFor="terms" className="font-light text-gray-500">I accept the <Link className="font-medium text-green-500 hover:underline" to="#"><Terms /></Link></label>
                   </div>
                 </div>
                 <button type="submit" className="w-full text-white bg-green-500 hover:bg-green-600 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center">Create an account</button>


### PR DESCRIPTION
What I did:
- Created a modal for T&C for the community board
- added the modal to the sign up page

![image](https://github.com/Resilient-Labs/nourish/assets/75923327/7a4c179f-4bdf-4d6b-8c77-0017f5192e62)

How to test:
- npm install
- npm start
- go to sign up page
- click on the T&C link in the sign up form to check if it works
